### PR TITLE
Added -v argument to print more details logs

### DIFF
--- a/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F30667381F2A0DE900EDE682 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667371F2A0DE900EDE682 /* Logger.swift */; };
+		F30667541F2A1BE200EDE682 /* StringGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667501F2A1BB900EDE682 /* StringGenerator.swift */; };
+		F30667551F2A1BE200EDE682 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667511F2A1BB900EDE682 /* Style.swift */; };
+		F30667561F2A1BE200EDE682 /* XcodeColorsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667521F2A1BB900EDE682 /* XcodeColorsSupport.swift */; };
+		F306675E1F2A1BEC00EDE682 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667471F2A1BB900EDE682 /* BackgroundColor.swift */; };
+		F306675F1F2A1BEC00EDE682 /* CodesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667481F2A1BB900EDE682 /* CodesParser.swift */; };
+		F30667601F2A1BEC00EDE682 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667491F2A1BB900EDE682 /* Color.swift */; };
+		F30667611F2A1BEC00EDE682 /* ControlCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F306674A1F2A1BB900EDE682 /* ControlCode.swift */; };
+		F30667621F2A1BEC00EDE682 /* ModesExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F306674B1F2A1BB900EDE682 /* ModesExtractor.swift */; };
+		F30667631F2A1BEC00EDE682 /* OutputTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F306674C1F2A1BB900EDE682 /* OutputTarget.swift */; };
+		F30667641F2A1BEC00EDE682 /* Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F306674E1F2A1BB900EDE682 /* Rainbow.swift */; };
+		F30667651F2A1BEC00EDE682 /* String+Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F306674F1F2A1BB900EDE682 /* String+Rainbow.swift */; };
 		F324B4991F22359500B5B8B4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = F324B4981F22359500B5B8B4 /* main.swift */; };
 		F324B4A01F22383D00B5B8B4 /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = F324B49F1F22383D00B5B8B4 /* Argument.swift */; };
 		F34A8F0D1F29934F00831771 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34A8F0C1F29934F00831771 /* Command.swift */; };
@@ -35,6 +47,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F30667371F2A0DE900EDE682 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		F30667471F2A1BB900EDE682 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
+		F30667481F2A1BB900EDE682 /* CodesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodesParser.swift; sourceTree = "<group>"; };
+		F30667491F2A1BB900EDE682 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		F306674A1F2A1BB900EDE682 /* ControlCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCode.swift; sourceTree = "<group>"; };
+		F306674B1F2A1BB900EDE682 /* ModesExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModesExtractor.swift; sourceTree = "<group>"; };
+		F306674C1F2A1BB900EDE682 /* OutputTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputTarget.swift; sourceTree = "<group>"; };
+		F306674E1F2A1BB900EDE682 /* Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rainbow.swift; sourceTree = "<group>"; };
+		F306674F1F2A1BB900EDE682 /* String+Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Rainbow.swift"; sourceTree = "<group>"; };
+		F30667501F2A1BB900EDE682 /* StringGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringGenerator.swift; sourceTree = "<group>"; };
+		F30667511F2A1BB900EDE682 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
+		F30667521F2A1BB900EDE682 /* XcodeColorsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeColorsSupport.swift; sourceTree = "<group>"; };
 		F324B4951F22359500B5B8B4 /* XCUITestHTMLReport */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XCUITestHTMLReport; sourceTree = BUILT_PRODUCTS_DIR; };
 		F324B4981F22359500B5B8B4 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		F324B49F1F22383D00B5B8B4 /* Argument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
@@ -69,6 +93,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F30667461F2A1BB900EDE682 /* Rainbow */ = {
+			isa = PBXGroup;
+			children = (
+				F30667471F2A1BB900EDE682 /* BackgroundColor.swift */,
+				F30667481F2A1BB900EDE682 /* CodesParser.swift */,
+				F30667491F2A1BB900EDE682 /* Color.swift */,
+				F306674A1F2A1BB900EDE682 /* ControlCode.swift */,
+				F306674B1F2A1BB900EDE682 /* ModesExtractor.swift */,
+				F306674C1F2A1BB900EDE682 /* OutputTarget.swift */,
+				F306674E1F2A1BB900EDE682 /* Rainbow.swift */,
+				F306674F1F2A1BB900EDE682 /* String+Rainbow.swift */,
+				F30667501F2A1BB900EDE682 /* StringGenerator.swift */,
+				F30667511F2A1BB900EDE682 /* Style.swift */,
+				F30667521F2A1BB900EDE682 /* XcodeColorsSupport.swift */,
+			);
+			path = Rainbow;
+			sourceTree = "<group>";
+		};
 		F324B48C1F22359500B5B8B4 = {
 			isa = PBXGroup;
 			children = (
@@ -90,6 +132,7 @@
 			children = (
 				F324B4981F22359500B5B8B4 /* main.swift */,
 				F3AB014C1F24600B00334580 /* HTMLTemplates.swift */,
+				F30667371F2A0DE900EDE682 /* Logger.swift */,
 				F3B7EE791F22F1D800E19B57 /* HTML */,
 				F3C0589F1F25E73C00EF51E1 /* Libraries */,
 				F3AB014B1F245F2A00334580 /* Models */,
@@ -137,6 +180,7 @@
 		F3C0589F1F25E73C00EF51E1 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				F30667461F2A1BB900EDE682 /* Rainbow */,
 				F3C058A11F25E74D00EF51E1 /* NSData+GZIP.h */,
 				F3C058A21F25E74D00EF51E1 /* NSData+GZIP.m */,
 				F3C058A01F25E74C00EF51E1 /* XCUITestHTMLReport-Bridging-Header.h */,
@@ -227,11 +271,23 @@
 				F3B7EE6E1F22449100E19B57 /* TargetDevice.swift in Sources */,
 				F3B7EE701F2247FA00E19B57 /* TestSummary.swift in Sources */,
 				F3B7EE6C1F2242DC00E19B57 /* Summary.swift in Sources */,
+				F306675E1F2A1BEC00EDE682 /* BackgroundColor.swift in Sources */,
 				F3AB011D1F23659D00334580 /* Attachment.swift in Sources */,
 				F324B4A01F22383D00B5B8B4 /* Argument.swift in Sources */,
 				F324B4991F22359500B5B8B4 /* main.swift in Sources */,
+				F306675F1F2A1BEC00EDE682 /* CodesParser.swift in Sources */,
+				F30667631F2A1BEC00EDE682 /* OutputTarget.swift in Sources */,
 				F34A8F0D1F29934F00831771 /* Command.swift in Sources */,
+				F30667601F2A1BEC00EDE682 /* Color.swift in Sources */,
+				F30667381F2A0DE900EDE682 /* Logger.swift in Sources */,
+				F30667611F2A1BEC00EDE682 /* ControlCode.swift in Sources */,
 				F3B7EE721F224A4200E19B57 /* Test.swift in Sources */,
+				F30667641F2A1BEC00EDE682 /* Rainbow.swift in Sources */,
+				F30667551F2A1BE200EDE682 /* Style.swift in Sources */,
+				F30667651F2A1BEC00EDE682 /* String+Rainbow.swift in Sources */,
+				F30667561F2A1BE200EDE682 /* XcodeColorsSupport.swift in Sources */,
+				F30667621F2A1BEC00EDE682 /* ModesExtractor.swift in Sources */,
+				F30667541F2A1BE200EDE682 /* StringGenerator.swift in Sources */,
 				F3B7EE6A1F2242D200E19B57 /* RunDestination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCUITestHTMLReport.xcscheme
+++ b/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCUITestHTMLReport.xcscheme
@@ -83,7 +83,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r ../../TestResults"
+            argument = "-r ../../TestResults -v"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCUITestHTMLReport.xcscheme
+++ b/XCUITestHTMLReport/XCUITestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCUITestHTMLReport.xcscheme
@@ -86,6 +86,10 @@
             argument = "-r ../../TestResults"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-h"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/BackgroundColor.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/BackgroundColor.swift
@@ -1,0 +1,42 @@
+//
+//  BackgroundColor.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/22.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+/// Valid background colors to use in `Rainbow`.
+public enum BackgroundColor: UInt8, ModeCode {
+    case black = 40
+    case red
+    case green
+    case yellow
+    case blue
+    case magenta
+    case cyan
+    case white
+    case `default` = 49
+    
+    public var value: UInt8 {
+        return rawValue
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/CodesParser.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/CodesParser.swift
@@ -1,0 +1,73 @@
+//
+//  CodesParser.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+protocol CodesParser {
+    associatedtype SourceType
+    func parse(modeCodes codes: [SourceType]) ->
+        (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?)
+}
+
+struct ConsoleCodesParser: CodesParser {
+    typealias SourceType = UInt8
+    func parse(modeCodes codes: [UInt8]) -> (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?) {
+        var color: Color? = nil
+        var backgroundColor: BackgroundColor? = nil
+        var styles: [Style]? = nil
+        
+        for code in codes {
+            if let c = Color(rawValue: code) {
+                color = c
+            } else if let bg = BackgroundColor(rawValue: code) {
+                backgroundColor = bg
+            } else if let style = Style(rawValue: code) {
+                if styles == nil {
+                    styles = []
+                }
+                styles!.append(style)
+            }
+        }
+        
+        return (color, backgroundColor, styles)
+    }
+}
+
+struct XcodeColorsCodesParser: CodesParser {
+    typealias SourceType = String
+    func parse(modeCodes codes: [String]) -> (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?) {
+        var color: Color? = nil
+        var backgroundColor: BackgroundColor? = nil
+        
+        for code in codes {
+            if let c = Color(xcodeColorsDescription: code) {
+                color = c
+            } else if let bg = BackgroundColor(xcodeColorsDescription: code) {
+                backgroundColor = bg
+            }
+        }
+        
+        return (color, backgroundColor, nil)
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Color.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Color.swift
@@ -1,0 +1,50 @@
+//
+//  Color.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/22.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+/// Valid text colors to use in `Rainbow`.
+public enum Color: UInt8, ModeCode {
+    case black = 30
+    case red
+    case green
+    case yellow
+    case blue
+    case magenta
+    case cyan
+    case white
+    case `default` = 39
+    case lightBlack = 90
+    case lightRed
+    case lightGreen
+    case lightYellow
+    case lightBlue
+    case lightMagenta
+    case lightCyan
+    case lightWhite
+    
+    public var value: UInt8 {
+        return rawValue
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/ControlCode.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/ControlCode.swift
@@ -1,0 +1,30 @@
+//
+//  ControlCode.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/22.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+struct ControlCode {
+    static let ESC = "\u{001B}"
+    static let CSI = "\(ESC)["
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/ModesExtractor.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/ModesExtractor.swift
@@ -1,0 +1,82 @@
+//
+//  ModesExtractor.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+protocol ModesExtractor {
+    associatedtype ResultType
+    func extract(_ string: String) -> (codes: [ResultType], text: String)
+}
+
+struct ConsoleModesExtractor: ModesExtractor {
+    typealias ResultType = UInt8
+    func extract(_ string: String) -> (codes: [UInt8], text: String) {
+        let token = ControlCode.CSI
+        
+        var index = string.index(string.startIndex, offsetBy: token.characters.count)
+        var codesString = ""
+        while string.characters[index] != "m" {
+            codesString.append(string.characters[index])
+            index = string.index(after: index)
+        }
+        
+        let codes = codesString.characters.split(separator: ";", maxSplits: Int.max, omittingEmptySubsequences: false).flatMap { UInt8(String($0)) }
+        let startIndex = string.index(after: index)
+        let endIndex = string.index(string.endIndex, offsetBy: -"\(token)0m".characters.count)
+        let text = String(string.characters[startIndex ..< endIndex])
+        
+        return (codes, text)
+    }
+}
+
+struct XcodeColorsModesExtractor: ModesExtractor {
+    typealias ResultType = String
+    func extract(_ string: String) -> (codes: [String], text: String) {
+        let token = ControlCode.CSI
+        var index = string.startIndex
+        
+        var codes = [String]()
+        
+        var outer = String(string.characters[index]) //Start index should be the ESC control code
+        while outer == ControlCode.ESC {
+            var codesString = ""
+            index = string.index(index, offsetBy: token.characters.count)
+            
+            while string.characters[index] != ";" {
+                codesString.append(string.characters[index])
+                index = string.index(after: index)
+            }
+            
+            codes.append(codesString)
+            index = string.index(after: index)
+            outer = String(string.characters[index])
+        }
+        
+        let startIndex = index
+        let endIndex = string.index(string.endIndex, offsetBy: -"\(token);".characters.count)
+        let text = String(string.characters[startIndex ..< endIndex])
+        
+        return (codes, text)
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/OutputTarget.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/OutputTarget.swift
@@ -1,0 +1,70 @@
+//
+//  OutputTarget.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
+
+private func getEnvValue(_ key: String) -> String? {
+    guard let value = getenv(key) else {
+        return nil
+    }
+    return String(cString: value)
+}
+
+
+///
+/**
+Output target of Rainbow.
+
+- Unknown: Unknown target.
+- Console: A valid console is detected connected.
+- XcodeColors: Used in Xcode with XcodeColors enabled.
+*/
+public enum OutputTarget {
+    case unknown
+    case console
+    case xcodeColors
+    
+    /// Detected output target by current envrionment.
+    static var current: OutputTarget = {
+        // Check if Xcode Colors is installed and enabled.
+        let xcodeColorsEnabled = (getEnvValue("XcodeColors") == "YES")
+        if xcodeColorsEnabled {
+            return .xcodeColors
+        }
+        
+        // Check if we are in any term env and the output is a tty.
+        let termType = getEnvValue("TERM")
+        if let t = termType, t.lowercased() != "dumb" && isatty(fileno(stdout)) != 0 {
+            return .console
+        }
+        
+        return .unknown
+    }()
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Rainbow.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Rainbow.swift
@@ -1,0 +1,96 @@
+//
+//  Rainbow.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/22.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/**
+ A Mode code represnet a component for colorizing the string.
+ It could be a `Color`, a `BackgroundColor` or a `Style`
+ */
+public protocol ModeCode {
+    var value: UInt8 { get }
+}
+
+/**
+ Setting for `Rainbow`.
+ */
+public struct Rainbow {
+    
+    /// Output target for `Rainbow`. `Rainbow` should detect correct target itself, so you rarely need to set it. 
+    /// However, if you want the colorized string to be different, or the detection is not correct, you can set it manually.
+    public static var outputTarget = OutputTarget.current
+    
+    /// Enable `Rainbow` to colorize string or not. Default is `true`.
+    public static var enabled = true
+    
+    static func extractModes(for string: String)
+        -> (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?, text: String)
+    {
+        if string.isConsoleStyle {
+            let result = ConsoleModesExtractor().extract(string)
+            let (color, backgroundColor, styles) = ConsoleCodesParser().parse(modeCodes: result.codes)
+            return (color, backgroundColor, styles, result.text)
+        } else if string.isXcodeColorsStyle {
+            let result = XcodeColorsModesExtractor().extract(string)
+            let (color, backgroundColor, _) = XcodeColorsCodesParser().parse(modeCodes: result.codes)
+            return (color, backgroundColor, nil, result.text)
+        } else {
+            return (nil, nil, nil, string)
+        }
+    }
+
+    static func generateString(forColor color: Color?,
+                             backgroundColor: BackgroundColor?,
+                                      styles: [Style]?,
+                                        text: String) -> String
+    {
+        guard enabled else {
+            return text
+        }
+        
+        switch outputTarget {
+        case .xcodeColors:
+            return XcodeColorsStringGenerator().generate(withStringColor: color, backgroundColor: backgroundColor, styles: styles, text: text)
+        case .console:
+            return ConsoleStringGenerator().generate(withStringColor: color, backgroundColor: backgroundColor, styles: styles, text: text)
+        case .unknown:
+            return text
+        }
+    }
+    
+}
+
+private extension String {
+    var isConsoleStyle: Bool {
+        let token = ControlCode.CSI
+        return hasPrefix(token) && hasSuffix("\(token)0m")
+    }
+    
+    var isXcodeColorsStyle: Bool {
+        let token = ControlCode.CSI
+        return hasPrefix(token) && hasSuffix("\(token);")
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/String+Rainbow.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/String+Rainbow.swift
@@ -1,0 +1,270 @@
+//
+//  String+Rainbow.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+// MARK: - Worker methods
+extension String {
+    /**
+     Apply a text color to current string.
+     
+     - parameter color: The color to apply.
+     
+     - returns: The colorized string based on current content.
+     */
+    public func applyingColor(_ color: Color) -> String {
+        return applyingCodes(color)
+    }
+    
+    /**
+     Remove a color from current string.
+     
+     - Note: This method will return the string itself if there is no color component in it.
+     Otherwise, a string without color component will be returned and other components will remain untouched..
+     
+     - returns: A string without color.
+     */
+    public func removingColor() -> String {
+        guard let _ = Rainbow.extractModes(for: self).color else {
+            return self
+        }
+        return applyingColor(.default)
+    }
+    
+    /**
+     Apply a background color to current string.
+     
+     - parameter color: The background color to apply.
+     
+     - returns: The background colorized string based on current content.
+     */
+    public func applyingBackgroundColor(_ color: BackgroundColor) -> String {
+        return applyingCodes(color)
+    }
+    
+    /**
+     Remove a background color from current string.
+     
+     - Note: This method will return the string itself if there is no background color component in it.
+     Otherwise, a string without background color component will be returned and other components will remain untouched.
+     
+     - returns: A string without color.
+     */
+    public func removingBackgroundColor() -> String {
+        guard let _ = Rainbow.extractModes(for: self).backgroundColor else {
+            return self
+        }
+
+        return applyingBackgroundColor(.default)
+    }
+    
+    /**
+     Apply a style to current string.
+     
+     - parameter style: The style to apply.
+     
+     - returns: A string with specified style applied.
+     */
+    public func applyingStyle(_ style: Style) -> String {
+        return applyingCodes(style)
+    }
+    
+    /**
+     Remove a style from current string.
+     
+     - parameter style: The style to remove.
+     
+     - returns: A string with specified style removed.
+     */
+    public func removingStyle(_ style: Style) -> String {
+        
+        guard Rainbow.enabled else {
+            return self
+        }
+        
+        let current = Rainbow.extractModes(for: self)
+        if let styles = current.styles {
+            var s = styles
+            var index = s.index(of: style)
+            while index != nil {
+                s.remove(at: index!)
+                index = s.index(of: style)
+            }
+            return Rainbow.generateString(
+                forColor: current.color,
+                backgroundColor: current.backgroundColor,
+                styles: s,
+                text: current.text
+            )
+        } else {
+            return self
+        }
+    }
+    
+    /**
+     Remove all styles from current string.
+
+     - Note: This method will return the string itself if there is no style components in it.
+     Otherwise, a string without stlye components will be returned and other color components will remain untouched.
+     
+     - returns: A string without style components.
+     */
+    public func removingAllStyles() -> String {
+        
+        guard Rainbow.enabled else {
+            return self
+        }
+        
+        let current = Rainbow.extractModes(for: self)
+        return Rainbow.generateString(
+            forColor: current.color,
+            backgroundColor: current.backgroundColor,
+            styles: nil,
+            text: current.text
+        )
+    }
+    
+    /**
+     Apply a series of modes to the string.
+     
+     - parameter codes: Component mode code to apply to the string.
+     
+     - returns: A string with specified modes applied.
+     */
+    public func applyingCodes(_ codes: ModeCode...) -> String {
+        
+        guard Rainbow.enabled else {
+            return self
+        }
+        
+        let current = Rainbow.extractModes(for: self)
+        let input = ConsoleCodesParser().parse(modeCodes: codes.map{ $0.value } )
+        
+        let color = input.color ?? current.color
+        let backgroundColor = input.backgroundColor ?? current.backgroundColor
+        var styles = [Style]()
+        
+        if let s = current.styles {
+            styles += s
+        }
+        
+        if let s = input.styles {
+            styles += s
+        }
+        
+        if codes.isEmpty {
+            return self
+        } else {
+            return Rainbow.generateString(
+                forColor: color,
+                backgroundColor: backgroundColor,
+                styles: styles.isEmpty ? nil : styles,
+                text: current.text
+            )
+        }
+    }
+}
+
+// MARK: - Colors Shorthand
+extension String {
+    /// String with black text.
+    public var black: String { return applyingColor(.black) }
+    /// String with red text.
+    public var red: String { return applyingColor(.red)   }
+    /// String with green text.
+    public var green: String { return applyingColor(.green) }
+    /// String with yellow text.
+    public var yellow: String { return applyingColor(.yellow) }
+    /// String with blue text.
+    public var blue: String { return applyingColor(.blue) }
+    /// String with magenta text.
+    public var magenta: String { return applyingColor(.magenta) }
+    /// String with cyan text.
+    public var cyan: String { return applyingColor(.cyan) }
+    /// String with white text.
+    public var white: String { return applyingColor(.white) }
+    /// String with light black text. Generally speaking, it means dark grey in some consoles.
+    public var lightBlack: String { return applyingColor(.lightBlack) }
+    /// String with light red text.
+    public var lightRed: String { return applyingColor(.lightRed) }
+    /// String with light green text.
+    public var lightGreen: String { return applyingColor(.lightGreen) }
+    /// String with light yellow text.
+    public var lightYellow: String { return applyingColor(.lightYellow) }
+    /// String with light blue text.
+    public var lightBlue: String { return applyingColor(.lightBlue) }
+    /// String with light magenta text.
+    public var lightMagenta: String { return applyingColor(.lightMagenta) }
+    /// String with light cyan text.
+    public var lightCyan: String { return applyingColor(.lightCyan) }
+    /// String with light white text. Generally speaking, it means light grey in some consoles.
+    public var lightWhite: String { return applyingColor(.lightWhite) }
+}
+
+// MARK: - Background Colors Shorthand
+extension String {
+    /// String with black background.
+    public var onBlack: String { return applyingBackgroundColor(.black) }
+    /// String with red background.
+    public var onRed: String { return applyingBackgroundColor(.red) }
+    /// String with green background.
+    public var onGreen: String { return applyingBackgroundColor(.green) }
+    /// String with yellow background.
+    public var onYellow: String { return applyingBackgroundColor(.yellow) }
+    /// String with blue background.
+    public var onBlue: String { return applyingBackgroundColor(.blue) }
+    /// String with magenta background.
+    public var onMagenta: String { return applyingBackgroundColor(.magenta) }
+    /// String with cyan background.
+    public var onCyan: String { return applyingBackgroundColor(.cyan) }
+    /// String with white background.
+    public var onWhite: String { return applyingBackgroundColor(.white) }
+}
+
+// MARK: - Styles Shorthand
+extension String {
+    /// String with bold style.
+    public var bold: String { return applyingStyle(.bold) }
+    /// String with dim style. This is not widely supported in all terminals. Use it carefully.
+    public var dim: String { return applyingStyle(.dim) }
+    /// String with italic style. This depends on whether a italic existing for the font family of terminals.
+    public var italic: String { return applyingStyle(.italic) }
+    /// String with underline style.
+    public var underline: String { return applyingStyle(.underline) }
+    /// String with blink style. This is not widely supported in all terminals, or need additional setting. Use it carefully.
+    public var blink: String { return applyingStyle(.blink) }
+    /// String with text color and background color swapped.
+    public var swap: String { return applyingStyle(.swap) }
+}
+
+// MARK: - Clear Modes Shorthand
+extension String {
+    /// Clear color component from string.
+    public var clearColor: String { return removingColor() }
+    /// Clear background color component from string.
+    public var clearBackgroundColor: String { return removingBackgroundColor() }
+    /// Clear styles components from string.
+    public var clearStyles: String { return removingAllStyles() }
+}
+

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/StringGenerator.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/StringGenerator.swift
@@ -1,0 +1,76 @@
+//
+//  StringGenerator.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+protocol StringGenerator {
+    func generate(withStringColor stringColor: Color?, backgroundColor: BackgroundColor?, styles: [Style]?, text: String) -> String
+}
+
+struct ConsoleStringGenerator: StringGenerator {
+    func generate(withStringColor stringColor: Color? = nil, backgroundColor: BackgroundColor? = nil, styles: [Style]? = nil, text: String) -> String {
+        var codes: [UInt8] = []
+        if let color = stringColor {
+            codes.append(color.value)
+        }
+        if let backgroundColor = backgroundColor {
+            codes.append(backgroundColor.value)
+        }
+        if let styles = styles {
+            codes += styles.map{$0.value}
+        }
+        
+        if codes.isEmpty {
+            return text
+        } else {
+            return "\(ControlCode.CSI)\(codes.map{String($0)}.joined(separator: ";"))m\(text)\(ControlCode.CSI)0m"
+        }
+    }
+}
+
+struct XcodeColorsStringGenerator: StringGenerator {
+    func generate(withStringColor stringColor: Color? = nil, backgroundColor: BackgroundColor? = nil, styles: [Style]? = nil, text: String) -> String {
+        
+        var result = ""
+        var added = false
+        
+        if let color = stringColor, color != .default {
+            result += "\(ControlCode.CSI)\(color.xcodeColorsDescription);"
+            added = true
+        }
+        
+        if let backgroundColor = backgroundColor, backgroundColor != .default {
+            result += "\(ControlCode.CSI)\(backgroundColor.xcodeColorsDescription);"
+            added = true
+        }
+        
+        result += text
+        
+        if added {
+            result += "\(ControlCode.CSI);"
+        }
+
+        return result
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Style.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/Style.swift
@@ -1,0 +1,40 @@
+//
+//  Style.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/22.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+/// Valid styles to use in `Rainbow`.
+public enum Style: UInt8, ModeCode {
+    case `default` = 0
+    case bold = 1
+    case dim = 2
+    case italic = 3
+    case underline = 4
+    case blink = 5
+    case swap = 7
+    
+    public var value: UInt8 {
+        return rawValue
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/XcodeColorsSupport.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Libraries/Rainbow/XcodeColorsSupport.swift
@@ -1,0 +1,108 @@
+//
+//  XcodeColorsSupport.swift
+//  Rainbow
+//
+//  Created by Wei Wang on 15/12/23.
+//
+//  Copyright (c) 2015 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+protocol XcodeColorsConvertible {
+    var xcodeColorsDescription: String { get }
+    init?(xcodeColorsDescription string: String)
+}
+
+// MARK: - XcodeColorsConvertible
+// Supports XcodeColors format of mode string.
+extension Color: XcodeColorsConvertible {
+    var xcodeColorsDescription: String {
+        switch self {
+        case .black: return "fg0,0,0"
+        case .red: return "fg255,0,0"
+        case .green: return "fg0,204,0"
+        case .yellow: return "fg255,255,0"
+        case .blue: return "fg0,0,255"
+        case .magenta: return "fg255,0,255"
+        case .cyan: return "fg0,255,255"
+        case .white: return "fg204,204,204"
+        case .default: return ""
+        case .lightBlack: return "fg128,128,128"
+        case .lightRed: return "fg255,102,102"
+        case .lightGreen: return "fg102,255,102"
+        case .lightYellow: return "fg255,255,102"
+        case .lightBlue: return "fg102,102,255"
+        case .lightMagenta: return "fg255,102,255"
+        case .lightCyan: return "fg102,255,255"
+        case .lightWhite: return "fg255,255,255"
+        }
+    }
+    
+    init?(xcodeColorsDescription string: String) {
+        switch string {
+        case Color.black.xcodeColorsDescription: self = .black
+        case Color.red.xcodeColorsDescription: self = .red
+        case Color.green.xcodeColorsDescription: self = .green
+        case Color.yellow.xcodeColorsDescription: self = .yellow
+        case Color.blue.xcodeColorsDescription: self = .blue
+        case Color.magenta.xcodeColorsDescription: self = .magenta
+        case Color.cyan.xcodeColorsDescription: self = .cyan
+        case Color.white.xcodeColorsDescription: self = .white
+        case Color.lightBlack.xcodeColorsDescription: self = .lightBlack
+        case Color.lightRed.xcodeColorsDescription: self = .lightRed
+        case Color.lightGreen.xcodeColorsDescription: self = .lightGreen
+        case Color.lightYellow.xcodeColorsDescription: self = .lightYellow
+        case Color.lightBlue.xcodeColorsDescription: self = .lightBlue
+        case Color.lightMagenta.xcodeColorsDescription: self = .lightMagenta
+        case Color.lightCyan.xcodeColorsDescription: self = .lightCyan
+        case Color.lightWhite.xcodeColorsDescription: self = .lightWhite
+        default: return nil
+        }
+    }
+}
+
+extension BackgroundColor: XcodeColorsConvertible {
+    var xcodeColorsDescription: String {
+        switch self {
+        case .black: return "bg0,0,0"
+        case .red: return "bg255,0,0"
+        case .green: return "bg0,204,0"
+        case .yellow: return "bg255,255,0"
+        case .blue: return "bg0,0,255"
+        case .magenta: return "bg255,0,255"
+        case .cyan: return "bg0,255,255"
+        case .white: return "bg204,204,204"
+        case .default: return ""
+        }
+    }
+    
+    init?(xcodeColorsDescription string: String) {
+        switch string {
+        case BackgroundColor.black.xcodeColorsDescription: self = .black
+        case BackgroundColor.red.xcodeColorsDescription: self = .red
+        case BackgroundColor.green.xcodeColorsDescription: self = .green
+        case BackgroundColor.yellow.xcodeColorsDescription: self = .yellow
+        case BackgroundColor.blue.xcodeColorsDescription: self = .blue
+        case BackgroundColor.magenta.xcodeColorsDescription: self = .magenta
+        case BackgroundColor.cyan.xcodeColorsDescription: self = .cyan
+        case BackgroundColor.white.xcodeColorsDescription: self = .white
+        default: return nil
+        }
+    }
+}

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Logger.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Logger.swift
@@ -1,0 +1,44 @@
+//
+//  Logger.swift
+//  XCUITestHTMLReport
+//
+//  Created by Titouan van Belle on 27.07.17.
+//  Copyright © 2017 Tito. All rights reserved.
+//
+
+import Foundation
+
+struct Logger
+{
+    static var verbose = false
+
+    static func error(_ message: String)
+    {
+        print("Error: ".red.bold + message)
+    }
+
+    static func success(_ message: String)
+    {
+        print(message.green.bold)
+    }
+
+    static func warning(_ message: String)
+    {
+        print("Warning: ".yellow.bold + message)
+    }
+
+    static func step(_ message: String)
+    {
+        if verbose {
+            print("\n" + message.bold)
+        }
+    }
+
+    static func substep(_ message: String)
+    {
+        if verbose {
+            print("  ▸ " + message)
+        }
+    }
+}
+

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/Activity.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/Activity.swift
@@ -60,7 +60,7 @@ struct Activity: HTML
         if let activityType = ActivityType(rawValue: rawActivityType) {
             type = activityType
         } else {
-            print("Activity type is not supported: \(rawActivityType)")
+            Logger.warning("Activity type is not supported: \(rawActivityType). Skipping activity: \(title)")
         }
 
         if let rawAttachments = dict["Attachments"] as? [[String : Any]] {

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/Argument.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/Argument.swift
@@ -10,16 +10,9 @@ import Foundation
 
 class Argument
 {
-    class func validate(_ value: String, forType type: ArgumentType) -> Bool
-    {
-        switch type {
-        case .path:
-            return FileManager.default.fileExists(atPath: value)
-        }
-    }
-
     enum ArgumentType: String {
         case path = "path"
+        case bool = "bool"
     }
 
     let shortFlag: String
@@ -28,8 +21,6 @@ class Argument
     let helpMessage: String
     let type: ArgumentType
     let required: Bool
-
-    var value: String?
 
     var usageString: String {
         guard required else {
@@ -51,5 +42,31 @@ class Argument
         self.helpMessage = helpMessage
         self.type = type
         self.required = required
+    }
+}
+
+class ValueArgument: Argument
+{
+    var value: String?
+
+    class func validate(_ value: String, forType type: ArgumentType) -> (Bool, String?)
+    {
+        switch type {
+        case .path:
+            return (FileManager.default.fileExists(atPath: value), "Invalid path: \(value)")
+        default:
+            return (false, "")
+        }
+    }
+}
+
+class BlockArgument: Argument
+{
+    var block:  () -> ()
+
+    init(_ shortFlag: String, _ optionName: String?, required: Bool, helpMessage: String, block: @escaping () -> ())
+    {
+        self.block = block
+        super.init(.bool, shortFlag, optionName, required: required, helpMessage: helpMessage)
     }
 }

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/Attachment.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/Attachment.swift
@@ -1,4 +1,3 @@
-
 //
 //  Attachment.swift
 //  XCUITestHTMLReport
@@ -38,7 +37,7 @@ struct Attachment: HTML
         if let attachmentType = AttachmentType(rawValue: typeRaw) {
             type = attachmentType
         } else {
-            print("Attachment type is not supported: \(typeRaw)")
+            Logger.warning("Attachment type is not supported: \(typeRaw). Skipping.")
         }
     }
 

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/Command.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/Command.swift
@@ -10,14 +10,9 @@ import Foundation
 
 struct Command
 {
-    var arguments: [Argument]
+    var arguments: [Argument]!
 
     var isValid: Bool {
-        if CommandLine.arguments.index(of: "-h") != nil {
-            print(usage)
-            exit(EXIT_SUCCESS)
-        }
-
         let flagIndexes = CommandLine.arguments.dropFirst().map { $0.first == "-" ? CommandLine.arguments.index(of: $0) : nil }.flatMap { $0 }
 
         for index in 0..<arguments.count {
@@ -27,29 +22,37 @@ struct Command
             let argIndex = CommandLine.arguments.index(of: argWithDash)
             if argument.required {
                 if argIndex == nil {
-                    print("Error: Argument \(argWithDash) is required")
+                    Logger.error("Argument \(argWithDash) is required")
                     return false
                 }
             }
 
-            let valueIndex = argIndex! + 1
-            if CommandLine.arguments.count == valueIndex || flagIndexes.contains(valueIndex) {
-                print("Error: No value was passed for argument \(argWithDash)")
-                return false
-            }
-
-            let value = CommandLine.arguments[valueIndex]
-
-            if !Argument.validate(value, forType: argument.type) {
-                if argument.required {
-                    print("Error: value passed to argument \(argWithDash) is invalid. Expected a \(argument.type.rawValue)")
-                    return false
-                } else {
-                    print("Warning")
+            if let blockArgument = argument as? BlockArgument {
+                if argIndex != nil {
+                    blockArgument.block()
                 }
-            }
+            } else if let valueArgument = argument as? ValueArgument {
+                let valueIndex = argIndex! + 1
+                if CommandLine.arguments.count == valueIndex || flagIndexes.contains(valueIndex) {
+                    Logger.error("No value was passed for argument \(argWithDash)")
+                    return false
+                }
 
-            argument.value = value
+                let value = CommandLine.arguments[valueIndex]
+
+                let result = ValueArgument.validate(value, forType: valueArgument.type)
+                if !result.0 {
+                    if valueArgument.required {
+                        Logger.error("Value passed to argument \(argWithDash) is invalid. \(result.1!)")
+                        return false
+                    } else {
+                        Logger.warning("value passed to argument \(argWithDash) is invalid. \(result.1!). Ignoring argument.")
+                        continue
+                    }
+                }
+
+                valueArgument.value = value
+            }
         }
 
         return true
@@ -59,9 +62,5 @@ struct Command
         let usageString = "\nUsage: xchtmlreport" + arguments.map { $0.usageString }.joined()
         let optionsString = "\n\nOptions:\n" + arguments.map { "    -\($0.shortFlag)               \($0.helpMessage)\n"}.joined()
         return usageString + optionsString
-    }
-
-    init(arguments args: [Argument]) {
-        arguments = args
     }
 }

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/RunDestination.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/RunDestination.swift
@@ -13,7 +13,10 @@ struct RunDestination
     var name: String
     var targetDevice: TargetDevice
 
-    init(dict: [String : Any]) {
+    init(dict: [String : Any])
+    {
+        Logger.substep("Parsing RunDestination")
+        
         name = dict["Name"] as! String
         targetDevice = TargetDevice(dict: dict["TargetDevice"] as! [String : Any])
     }

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/TargetDevice.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/TargetDevice.swift
@@ -14,7 +14,10 @@ struct TargetDevice
     var osVersion: String
     var model: String
 
-    init(dict: [String : Any]) {
+    init(dict: [String : Any])
+    {
+        Logger.substep("Parsing TargetDevice")
+        
         identifier = dict["Identifier"] as! String
         osVersion = dict["OperatingSystemVersion"] as! String
         model = dict["ModelName"] as! String

--- a/XCUITestHTMLReport/XCUITestHTMLReport/Models/TestSummary.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/Models/TestSummary.swift
@@ -46,7 +46,10 @@ struct TestSummary: HTML
         return status
     }
 
-    init(dict: [String : Any]) {
+    init(dict: [String : Any])
+    {
+        Logger.substep("Parsing TestSummary")
+        
         uuid = NSUUID().uuidString
         testName = dict["TestName"] as! String
         let rawTests = dict["Tests"] as! [[String: Any]]

--- a/XCUITestHTMLReport/XCUITestHTMLReport/main.swift
+++ b/XCUITestHTMLReport/XCUITestHTMLReport/main.swift
@@ -8,8 +8,17 @@
 
 import Foundation
 
-var result = Argument(.path, "r", "resultBundePath", required: true, helpMessage: "Path to the result bundle")
-var command = Command(arguments: [result])
+var command = Command()
+var help = BlockArgument("h", "", required: false, helpMessage: "Print usage and available options") {
+    print(command.usage)
+    exit(EXIT_SUCCESS)
+}
+var verbose = BlockArgument("v", "", required: false, helpMessage: "Provide additional logs") {
+    Logger.verbose = true
+}
+var result = ValueArgument(.path, "r", "resultBundePath", required: true, helpMessage: "Path to the result bundle")
+
+command.arguments = [help, verbose, result]
 
 if !command.isValid {
     print(command.usage)
@@ -17,24 +26,28 @@ if !command.isValid {
 }
 
 let summary = Summary(root: result.value!)
-let activityLogs = summary.activityLogs
 
-do {
-    try activityLogs.write(toFile: "\(result.value!)/logs.txt", atomically: false, encoding: .utf8)
-}
-catch {
-    print("An error has occured while create the activity log file")
+if let activityLogs = summary.activityLogs {
+    do {
+        try activityLogs.write(toFile: "\(result.value!)/logs.txt", atomically: false, encoding: .utf8)
+    }
+    catch let e {
+        Logger.error("An error has occured while create the activity log file. Error: \(e)")
+    }
 }
 
+Logger.step("Building HTML..")
 let html = summary.html
 
 do {
     let path = "\(result.value!)/index.html"
+    Logger.substep("Writing report to \(path)")
+
     try html.write(toFile: path, atomically: false, encoding: .utf8)
-    print("Report successfully created at \(path)")
+    Logger.success("\nReport successfully created at \(path)")
 }
-catch {
-    print("An error has occured while creating the report")
+catch let e {
+    Logger.error("An error has occured while creating the report. Error: \(e)")
 }
 
 exit(EXIT_SUCCESS)


### PR DESCRIPTION
Ticket: #2 

```
$ ./xchtmlreport -r TestResults -v

Parsing Test Summaries
  ▸ Searching for action_TestSummaries.plist in TestResults
  ▸ Found action_TestSummaries.plist at path: TestResults/2_Test/action_TestSummaries.plist
  ▸ Parsing RunDestination
  ▸ Parsing TargetDevice
  ▸ Parsing TestSummary

Parsing Activity Logs
  ▸ Searching for action.xcactivitylog in TestResults
  ▸ Found TestResults/2_Test/action.xcactivitylog at path: TestResults/2_Test/action.xcactivitylog
  ▸ Gunzipping activity logs

Building HTML..
  ▸ Writing report to TestResults/index.html

Report successfully created at TestResults/index.html
```